### PR TITLE
Fix deprecated h5py usage

### DIFF
--- a/CNN.py
+++ b/CNN.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import numpy as numpy
+import numpy as np
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Activation, Flatten
 from keras.layers import Conv1D, MaxPooling1D, LeakyReLU, PReLU
@@ -22,8 +22,8 @@ set_session(tf.Session(config=config))
 
 
 with h5py.File(''.join(['bitcoin2015to2017_close.h5']), 'r') as hf:
-    datas = hf['inputs'].value
-    labels = hf['outputs'].value
+    datas = hf['inputs'][:]
+    labels = hf['outputs'][:]
 
 
 output_file_name='bitcoin2015to2017_close_CNN_2_relu'

--- a/GRU.py
+++ b/GRU.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import numpy as numpy
+import numpy as np
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Activation, Flatten,Reshape
 from keras.layers import Conv1D, MaxPooling1D, LeakyReLU
@@ -22,8 +22,8 @@ config.gpu_options.allow_growth = True
 set_session(tf.Session(config=config))
 
 with h5py.File(''.join(['bitcoin2015to2017_close.h5']), 'r') as hf:
-    datas = hf['inputs'].value
-    labels = hf['outputs'].value
+    datas = hf['inputs'][:]
+    labels = hf['outputs'][:]
 
 
 output_file_name='bitcoin2015to2017_close_GRU_1_tanh_relu_'

--- a/GRU_WF.py
+++ b/GRU_WF.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import numpy as numpy
+import numpy as np
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Activation, Flatten,Reshape
 from keras.layers import Conv1D, MaxPooling1D
@@ -22,8 +22,8 @@ config.gpu_options.allow_growth = True
 set_session(tf.Session(config=config))
 
 with h5py.File(''.join(['data/allcoin2015to2017_wf.h5']), 'r') as hf:
-    datas = hf['inputs'].value
-    labels = hf['outputs'].value
+    datas = hf['inputs'][:]
+    labels = hf['outputs'][:]
 
 
 nb_partitions = datas.shape[0]
@@ -48,7 +48,7 @@ for partition in range(nb_partitions):
     csvlog = CSVLogger('result/'+output_file_name+'.csv', append=True)
     checkpoint = ModelCheckpoint('weights/'+output_file_name+'partition_'+str(partition)+'.hdf5', monitor='val_loss', verbose=1, save_best_only=True, mode='min')
     cb_list = [early,csvlog,checkpoint]
-    print training_datas.shape, validation_datas.shape, training_labels.shape, validation_labels.shape
+    print(training_datas.shape, validation_datas.shape, training_labels.shape, validation_labels.shape)
     #build model
     model = Sequential()
     model.add(CuDNNGRU(units=units, input_shape=(step_size,nb_features),return_sequences=True))

--- a/LSTM.py
+++ b/LSTM.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import numpy as numpy
+import numpy as np
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Activation, Flatten,Reshape
 from keras.layers import Conv1D, MaxPooling1D
@@ -22,8 +22,8 @@ config.gpu_options.allow_growth = True
 set_session(tf.Session(config=config))
 
 with h5py.File(''.join(['data/bitcoin2015to2017_close.h5']), 'r') as hf:
-    datas = hf['inputs'].value
-    labels = hf['outputs'].value
+    datas = hf['inputs'][:]
+    labels = hf['outputs'][:]
 
 
 

--- a/PlotRegularization.py
+++ b/PlotRegularization.py
@@ -35,13 +35,13 @@ import matplotlib.pyplot as plt
 
 
 with h5py.File(''.join(['bitcoin2015to2017_close.h5']), 'r') as hf:
-    datas = hf['inputs'].value
-    labels = hf['outputs'].value
-    input_times = hf['input_times'].value
-    output_times = hf['output_times'].value
-    original_inputs = hf['original_inputs'].value
-    original_outputs = hf['original_outputs'].value
-    original_datas = hf['original_datas'].value
+    datas = hf['inputs'][:]
+    labels = hf['outputs'][:]
+    input_times = hf['input_times'][:]
+    output_times = hf['output_times'][:]
+    original_inputs = hf['original_inputs'][:]
+    original_outputs = hf['original_outputs'][:]
+    original_datas = hf['original_datas'][:]
 
 
 # In[3]:
@@ -87,8 +87,8 @@ set_session(tf.Session(config=config))
 
 ground_true = np.append(validation_original_inputs,validation_original_outputs, axis=1)
 ground_true_times = np.append(validation_input_times,validation_output_times, axis=1)
-print ground_true_times.shape
-print ground_true.shape
+print(ground_true_times.shape)
+print(ground_true.shape)
 
 
 # In[8]:
@@ -157,7 +157,7 @@ results = pd.DataFrame()
 for reg in regs:
     
     name = ('l1 %.4f,l2 %.4f' % (reg.l1, reg.l2))
-    print "Training "+ str(name)
+    print("Training "+ str(name))
     results[name] = experiment(validation_datas,validation_labels,original_datas,ground_true,ground_true_times,validation_original_outputs, validation_output_times, nb_repeat,reg)
 # print(results.describe())
 # save boxplot
@@ -191,7 +191,7 @@ results = pd.DataFrame()
 for reg in regs:
     
     name = ('l1 %.4f,l2 %.4f' % (reg.l1, reg.l2))
-    print "Training "+ str(name)
+    print("Training "+ str(name))
     results[name] = experiment(validation_datas,validation_labels,original_datas,ground_true,ground_true_times,validation_original_outputs, validation_output_times, nb_repeat,reg)
 
 results.describe().to_csv('result/lstm_kernel_reg.csv')
@@ -224,7 +224,7 @@ results = pd.DataFrame()
 for reg in regs:
     
     name = ('l1 %.4f,l2 %.4f' % (reg.l1, reg.l2))
-    print "Training "+ str(name)
+    print("Training "+ str(name))
     results[name] = experiment(validation_datas,validation_labels,original_datas,ground_true,ground_true_times,validation_original_outputs, validation_output_times, nb_repeat,reg)
 
 results.describe().to_csv('result/lstm_activity_reg.csv')
@@ -257,7 +257,7 @@ results = pd.DataFrame()
 for reg in regs:
     
     name = ('l1 %.4f,l2 %.4f' % (reg.l1, reg.l2))
-    print "Training "+ str(name)
+    print("Training "+ str(name))
     results[name] = experiment(validation_datas,validation_labels,original_datas,ground_true,ground_true_times,validation_original_outputs, validation_output_times, nb_repeat,reg)
 
 results.describe().to_csv('result/lstm_recurrent_reg.csv')

--- a/Prediction.py
+++ b/Prediction.py
@@ -36,12 +36,12 @@ os.environ['TF_CPP_MIN_LOG_LEVEL']='2'
 
 
 with h5py.File(''.join(['bitcoin2012_2017_256_16.h5']), 'r') as hf:
-    datas = hf['inputs'].value
-    labels = hf['outputs'].value
-    input_times = hf['input_times'].value
-    output_times = hf['output_times'].value
-    original_datas = hf['original_datas'].value
-    original_outputs = hf['original_outputs'].value
+    datas = hf['inputs'][:]
+    labels = hf['outputs'][:]
+    input_times = hf['input_times'][:]
+    output_times = hf['output_times'][:]
+    original_datas = hf['original_datas'][:]
+    original_outputs = hf['original_outputs'][:]
 
 
 
@@ -150,7 +150,7 @@ predicted_inverted = np.array(predicted_inverted)[:,:,0].reshape(-1)
 
 
 # In[8]:
-print output_times.shape, ground_true.shape
+print(output_times.shape, ground_true.shape)
 
 plt.plot(output_times[-1000:],ground_true[-1000:])
 plt.plot(output_times[-1000:],predicted_inverted[-1000:])


### PR DESCRIPTION
## Summary
- fix numpy import names
- update h5py dataset access
- use Python 3 print function

## Testing
- `python3 -m py_compile CNN.py GRU.py GRU_WF.py LSTM.py PlotRegularization.py Prediction.py PastSampler.py DataProcessor.py`

------
https://chatgpt.com/codex/tasks/task_e_687f26ce99548323b87b9086a1726b61